### PR TITLE
Move to excalirender + support png exports + fix preview logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For me, this synchronization makes both tools more useful: I can easily draw in 
 
 Excalidraw is a web application. `org-excalidraw` takes advantage of the File Handling API to register Excalidraw as a file handler for `.excalidraw` files.
 
-It also requires a few external dependencies outside of Emacs and `org-mode` for converting between excalidraw json and svg.
+It also requires a few external dependencies outside of Emacs and `org-mode` for converting between excalidraw json and image previews.
 
 `org-excalidraw` has only been tested against Chromium based browsers.
 
@@ -59,14 +59,27 @@ Using `use-pacakge`:
 
 `org-excalidraw` requires external dependencies outside of Emacs and `org-mode`.
 
-1. We need to programmatically export excalidraw files to `.svg` for display.
+1. We need to programmatically export excalidraw files to `.svg` or `.png` for display.
 org-excalidraw depends on [excalirender](https://github.com/JonRC/excalirender) to do this. It must be available on your system's PATH.
 
-   Build and install `excalirender` from its repository, then make sure the binary is named `excalirender` and is on your PATH. For the macOS ARM64, either use the docker command  or, use the [gleek/excalirender fork](https://github.com/gleek/excalirender) to build a single binary.
+   Build and install `excalirender` from its repository, then make sure the binary is named `excalirender` and is on your PATH. For macOS ARM64, either use the Docker command or use the [gleek/excalirender fork](https://github.com/gleek/excalirender) to build a single binary.
 
    You can customize the exporter path with `org-excalidraw-export-program`.
+   The rendered preview format defaults to SVG and can be changed to PNG:
 
-2. To correctly display the produced SVGs, your system may need the Excalidraw fonts installed, depending on your SVG viewer and exporter options.
+   ```elisp
+   (setq org-excalidraw-export-format "png")
+   ```
+
+   Exports use `--scale 2` by default so PNG previews are sharper in Emacs. Extra exporter arguments can be passed with `org-excalidraw-export-arguments`. For example, `excalirender` supports dark mode and custom backgrounds:
+
+   ```elisp
+   (setq org-excalidraw-export-arguments '("--scale" "2" "--dark"))
+   ;; or
+   (setq org-excalidraw-export-arguments '("--scale" "2" "--background" "#111111"))
+   ```
+
+2. To correctly display SVG previews, your system may need the Excalidraw fonts installed, depending on your SVG viewer and exporter options. PNG previews are rasterized by `excalirender`, so they preserve the rendered font appearance in Emacs.
 
 3. Install [excalidraw](https://www.excalidraw.com) as a PWA using Chrome. After doing this, you should be able to launch excalidraw from your system as if it was an application.
 
@@ -85,4 +98,4 @@ This does 2 things:
 2. Inserts a link to this file with a custom `excalidraw:` type. The `excalidraw:` link type both displays the image inline and will open the drawing in excalidraw for editing when followed.
 
 
-As long as `excalirender` is available and configured correctly, all changes saved in the excalidraw application will update the corresponding svg files.
+As long as `excalirender` is available and configured correctly, all changes saved in the excalidraw application will update the corresponding preview image files.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ Using `use-pacakge`:
 `org-excalidraw` requires external dependencies outside of Emacs and `org-mode`.
 
 1. We need to programmatically export excalidraw files to `.svg` for display.
-org-excalidraw depends on [excalidraw_export](https://github.com/Timmmm/excalidraw_export) to do this. It must be available on your system's PATH.
-NOTE: you may need to install some dependencies like `canvas` for this package to work correctly.
+org-excalidraw depends on [excalirender](https://github.com/JonRC/excalirender) to do this. It must be available on your system's PATH.
 
-2. To correctly display the produced SVGs, your system needs some fonts installed.
-[The excalidraw_export repo provides these as well](https://github.com/Timmmm/excalidraw_export/tree/master/src).
+   Build and install `excalirender` from its repository, then make sure the binary is named `excalirender` and is on your PATH. For the macOS ARM64, either use the docker command  or, use the [gleek/excalirender fork](https://github.com/gleek/excalirender) to build a single binary.
+
+   You can customize the exporter path with `org-excalidraw-export-program`.
+
+2. To correctly display the produced SVGs, your system may need the Excalidraw fonts installed, depending on your SVG viewer and exporter options.
 
 3. Install [excalidraw](https://www.excalidraw.com) as a PWA using Chrome. After doing this, you should be able to launch excalidraw from your system as if it was an application.
 
@@ -83,4 +85,4 @@ This does 2 things:
 2. Inserts a link to this file with a custom `excalidraw:` type. The `excalidraw:` link type both displays the image inline and will open the drawing in excalidraw for editing when followed.
 
 
-As long as `excalidraw_export` is available and configured correctly, all changes saved in the excalidraw application will update the corresponding svg files.
+As long as `excalirender` is available and configured correctly, all changes saved in the excalidraw application will update the corresponding svg files.

--- a/org-excalidraw.el
+++ b/org-excalidraw.el
@@ -38,6 +38,7 @@
 (require 'filenotify)
 (require 'org-id)
 (require 'ol)
+(require 'subr-x)
 
 (defun org-excalidraw--default-base ()
   "Get default JSON template used for new excalidraw files."
@@ -70,8 +71,18 @@
   :group 'org-excalidraw)
 
 (defcustom org-excalidraw-export-program "excalirender"
-  "Program used to export excalidraw files to SVG."
+  "Program used to export excalidraw files to image previews."
   :type 'string
+  :group 'org-excalidraw)
+
+(defcustom org-excalidraw-export-format "svg"
+  "Image format used for rendered excalidraw previews."
+  :type '(choice (const "svg") (const "png"))
+  :group 'org-excalidraw)
+
+(defcustom org-excalidraw-export-arguments '("--scale" "2")
+  "Additional arguments passed to `org-excalidraw-export-program'."
+  :type '(repeat string)
   :group 'org-excalidraw)
 
 (defun org-excalidraw--validate-excalidraw-file (path)
@@ -80,12 +91,24 @@
     (error
      "Excalidraw file must have .excalidraw extension")))
 
+(defun org-excalidraw--preview-path (path)
+  "Return rendered preview path for excalidraw file at PATH."
+  (concat path "." org-excalidraw-export-format))
+
+(defun org-excalidraw--shell-cmd-to-image (path)
+  "Construct shell cmd for converting excalidraw file with PATH to an image."
+  (string-join
+   (append
+    (list (shell-quote-argument org-excalidraw-export-program))
+    (mapcar #'shell-quote-argument org-excalidraw-export-arguments)
+    (list (shell-quote-argument path)
+          "-o"
+          (shell-quote-argument (org-excalidraw--preview-path path))))
+   " "))
+
 (defun org-excalidraw--shell-cmd-to-svg (path)
-  "Construct shell cmd for converting excalidraw file with PATH to svg."
-  (format "%s %s -o %s"
-          (shell-quote-argument org-excalidraw-export-program)
-          (shell-quote-argument path)
-          (shell-quote-argument (concat path ".svg"))))
+  "Construct shell cmd for converting excalidraw file with PATH to an image."
+  (org-excalidraw--shell-cmd-to-image path))
 
 (defun org-excalidraw--shell-cmd-open (path os-type)
   "Construct shell cmd to open excalidraw file with PATH for OS-TYPE."
@@ -93,18 +116,26 @@
       (concat "open " (shell-quote-argument path))
     (concat "xdg-open " (shell-quote-argument path))))
 
-(defun org-excalidraw--open-file-from-svg (path)
-  "Open corresponding .excalidraw file for svg located at PATH."
-  (let ((excal-file-path (string-remove-suffix ".svg" path)))
+(defun org-excalidraw--open-file-from-preview (path)
+  "Open corresponding .excalidraw file for preview image located at PATH."
+  (let ((excal-file-path (replace-regexp-in-string "\\.\\(svg\\|png\\)\\'" "" path)))
     (org-excalidraw--validate-excalidraw-file excal-file-path)
     (shell-command (org-excalidraw--shell-cmd-open excal-file-path system-type))))
 
+(defun org-excalidraw--open-preview-file (path _link)
+  "Open corresponding .excalidraw file for preview image at PATH."
+  (org-excalidraw--open-file-from-preview path))
+
+(defun org-excalidraw--open-file-from-svg (path)
+  "Open corresponding .excalidraw file for svg located at PATH."
+  (org-excalidraw--open-file-from-preview path))
+
 (defun org-excalidraw--handle-file-change (event)
-  "Handle file update EVENT to convert files to svg."
+  "Handle file update EVENT to convert files to preview images."
   (when (string-equal (cadr event)  "renamed")
     (let ((filename (cadddr event)))
       (when (string-suffix-p ".excalidraw" filename)
-        (shell-command (concat (org-excalidraw--shell-cmd-to-svg filename) " 2> /dev/null") nil nil)
+        (shell-command (concat (org-excalidraw--shell-cmd-to-image filename) " 2> /dev/null") nil nil)
         (org-display-inline-images)))))
 
 ;;;###
@@ -114,7 +145,7 @@
   (interactive)
   (let* ((filename (format "%s.excalidraw" (org-id-uuid)))
          (path (expand-file-name filename org-excalidraw-directory))
-         (link (format "[[file:%s.svg]]" path)))
+         (link (format "[[file:%s]]" (org-excalidraw--preview-path path))))
     (org-excalidraw--validate-excalidraw-file path)
     (insert link)
     (with-temp-file path (insert org-excalidraw-base))
@@ -129,7 +160,7 @@
     (error
      "Excalidraw directory %s does not exist"
      org-excalidraw-directory))
-  (push '("\\.excalidraw.svg\\'" . "echo '%s' | sed 's/.svg//' | xargs open") org-file-apps)
+  (push '("\\.excalidraw\\.\\(?:svg\\|png\\)\\'" . org-excalidraw--open-preview-file) org-file-apps)
   (file-notify-add-watch org-excalidraw-directory '(change) 'org-excalidraw--handle-file-change))
 
 

--- a/org-excalidraw.el
+++ b/org-excalidraw.el
@@ -69,6 +69,11 @@
   :type 'string
   :group 'org-excalidraw)
 
+(defcustom org-excalidraw-export-program "excalirender"
+  "Program used to export excalidraw files to SVG."
+  :type 'string
+  :group 'org-excalidraw)
+
 (defun org-excalidraw--validate-excalidraw-file (path)
   "Validate the excalidraw file at PATH is usable."
   (unless (string-suffix-p ".excalidraw" path)
@@ -77,7 +82,10 @@
 
 (defun org-excalidraw--shell-cmd-to-svg (path)
   "Construct shell cmd for converting excalidraw file with PATH to svg."
-  (concat "excalidraw_export --rename_fonts=true " (format "\"%s\"" path)))
+  (format "%s %s -o %s"
+          (shell-quote-argument org-excalidraw-export-program)
+          (shell-quote-argument path)
+          (shell-quote-argument (concat path ".svg"))))
 
 (defun org-excalidraw--shell-cmd-open (path os-type)
   "Construct shell cmd to open excalidraw file with PATH for OS-TYPE."

--- a/tests/test-org-excalidraw.el
+++ b/tests/test-org-excalidraw.el
@@ -17,7 +17,17 @@
 
   (it "formats a command compatible with excalirender"
     (expect (org-excalidraw--shell-cmd-to-svg excal-path) :to-equal
-            "excalirender home/excalidraw\\ drawings/my-drawing.excalidraw -o home/excalidraw\\ drawings/my-drawing.excalidraw.svg")))
+            "excalirender --scale 2 home/excalidraw\\ drawings/my-drawing.excalidraw -o home/excalidraw\\ drawings/my-drawing.excalidraw.svg"))
+
+  (it "formats a png export command"
+    (let ((org-excalidraw-export-format "png"))
+      (expect (org-excalidraw--shell-cmd-to-image excal-path) :to-equal
+              "excalirender --scale 2 home/excalidraw\\ drawings/my-drawing.excalidraw -o home/excalidraw\\ drawings/my-drawing.excalidraw.png")))
+
+  (it "includes extra export arguments"
+    (let ((org-excalidraw-export-arguments '("--scale" "2" "--dark" "--background" "#111111")))
+      (expect (org-excalidraw--shell-cmd-to-image excal-path) :to-equal
+              "excalirender --scale 2 --dark --background \\#111111 home/excalidraw\\ drawings/my-drawing.excalidraw -o home/excalidraw\\ drawings/my-drawing.excalidraw.svg"))))
 
 (describe
   "checks external dependencies on initialization"

--- a/tests/test-org-excalidraw.el
+++ b/tests/test-org-excalidraw.el
@@ -15,9 +15,9 @@
             :to-equal
             "xdg-open home/excalidraw\\ drawings/my-drawing.excalidraw"))
 
-  (it "formats a command compatible with excalidraw_export"
+  (it "formats a command compatible with excalirender"
     (expect (org-excalidraw--shell-cmd-to-svg excal-path) :to-equal
-            "excalidraw_export --rename_fonts=true \"home/excalidraw drawings/my-drawing.excalidraw\"")))
+            "excalirender home/excalidraw\\ drawings/my-drawing.excalidraw -o home/excalidraw\\ drawings/my-drawing.excalidraw.svg")))
 
 (describe
   "checks external dependencies on initialization"


### PR DESCRIPTION
[Excalirender](https://github.com/JonRC/excalirender) is a newer convertor for excalidraw -> {png, svg, pdf}. It can run as a standalone binary so has no issues with rendering hand-drawn vs shapes.

This also supports png export, which preserves the excalidraw fonts (which Emacs can't render with svg)

 For rendering, we've moved to directly using file: links which simplifies the rendering for org and also opens the files in Excalidraw PWA

